### PR TITLE
Added a check to validate the provider in machineClass

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -12,3 +12,4 @@ providerSpec:
 secretRef: # If required
   name: test-secret
   namespace: default # Namespace where the controller would watch
+provider: "Yandex"

--- a/pkg/provider/core.go
+++ b/pkg/provider/core.go
@@ -33,6 +33,9 @@ import (
 
 const (
 	apiTimeout = 10 * time.Minute
+
+	// ProviderYandex represents the cloud provider for the MachineClass for this controller
+	ProviderYandex = "Yandex"
 )
 
 // NOTE
@@ -70,6 +73,12 @@ func (p *Provider) CreateMachine(ctx context.Context, req *driver.CreateMachineR
 	// Log messages to track request
 	klog.V(2).Infof("Machine creation request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine creation request has been processed for %q", req.Machine.Name)
+
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderYandex {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderYandex)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	var (
 		machine      = req.Machine
@@ -184,6 +193,12 @@ func (p *Provider) DeleteMachine(ctx context.Context, req *driver.DeleteMachineR
 	klog.V(2).Infof("Machine deletion request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderYandex {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderYandex)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	var (
 		machine = req.Machine
 		secret  = req.Secret
@@ -237,6 +252,12 @@ func (p *Provider) GetMachineStatus(ctx context.Context, req *driver.GetMachineS
 	klog.V(2).Infof("Get request has been recieved for %q", req.Machine.Name)
 	defer klog.V(2).Infof("Machine get request has been processed successfully for %q", req.Machine.Name)
 
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderYandex {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderYandex)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	var (
 		machine = req.Machine
 		secret  = req.Secret
@@ -281,6 +302,12 @@ func (p *Provider) ListMachines(ctx context.Context, req *driver.ListMachinesReq
 	// Log messages to track start and end of request
 	klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
 	defer klog.V(2).Infof("List machines request has been recieved for %q", req.MachineClass.Name)
+
+	// Check if the MachineClass is for the supported cloud provider
+	if req.MachineClass.Provider != ProviderYandex {
+		err := fmt.Errorf("Requested for Provider '%s', we only support '%s'", req.MachineClass.Provider, ProviderYandex)
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 
 	var (
 		machineClass = req.MachineClass


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the check to validate the support for the referred provider in the MachineClass

**Which issue(s) this PR fixes**:
Fixes [#599](https://github.com/gardener/machine-controller-manager/issues/599)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement user
NONE
```